### PR TITLE
feature: add String support to `toDataView` function

### DIFF
--- a/__tests__/todataview.test.ts
+++ b/__tests__/todataview.test.ts
@@ -1,13 +1,19 @@
 import toDataView from '@/toDataView'
+import { stringToBytes } from '@/conversion'
 
 describe( 'toDataView' , () => {
 
 	const rawValue	= 'some value here!'
-	const bytes		= (
-		typeof window !== 'undefined'
-		? [ ...new TextEncoder().encode( rawValue ) ]
-		: [ ...Buffer.from( rawValue ) ]
-	)
+	const bytes		= stringToBytes( rawValue )
+
+	it( 'supports String input', () => {
+		const dataView = toDataView( rawValue )
+		
+		expect( dataView ).toBeInstanceOf( DataView )
+		expect( dataView.byteLength ).toBe( bytes.length )
+		expect( Buffer.from( dataView.buffer ).toString() ).toBe( rawValue )		
+	} )
+
 
 	it( 'supports Array of bytes', () => {
 		const dataView = toDataView( bytes )
@@ -26,9 +32,9 @@ describe( 'toDataView' , () => {
 	} )
 
 
-	it( 'supports Uint8Array', () => {
-		const uint8Array	= new Uint8Array( bytes )
-		const dataView		= toDataView( uint8Array )
+	it( 'supports Int8Array', () => {
+		const int8Array	= new Int8Array( bytes )
+		const dataView	= toDataView( int8Array )
 
 		expect( dataView ).toBeInstanceOf( DataView )
 		expect( dataView.byteLength ).toBe( bytes.length )
@@ -95,7 +101,7 @@ describe( 'toDataView' , () => {
 
 		try {
 			// @ts-expect-error negative testing
-			toDataView( bytes.join( ',' ) )
+			toDataView( bytes.at( 0 ) )
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch ( error ) {
 			pass = true

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -1,0 +1,22 @@
+/**
+ * Convert a String into an Array of bytes.
+ * 
+ * @param string The string to convert.
+ * @returns An Array of bytes.
+ */
+export const stringToBytes = ( string: string ) => (
+	[ ...stringToBuffer( string ) ]
+)
+
+
+/**
+ * Convert a String into a Uint8Array or Node.js Buffer.
+ * 
+ * @param string The string to convert.
+ * @returns A Uint8Array or Node.js Buffer.
+ */
+export const stringToBuffer = ( string: string ) => (
+	typeof window !== 'undefined'
+		? new Uint8Array( new TextEncoder().encode( string ) )
+		: Buffer.from( string )
+)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as toDataView } from './toDataView'
+export * from './conversion'

--- a/src/toDataView.ts
+++ b/src/toDataView.ts
@@ -1,5 +1,9 @@
+import { stringToBytes } from './conversion'
+
 export type ToDataViewInput = (
+	| string
 	| number[]
+	| Buffer
 	| ArrayBuffer
 	| Int8Array
 	| Int16Array
@@ -18,6 +22,10 @@ export type ToDataViewInput = (
  * @returns The `DataView` of the given data. Throws a new Exception on failure.
  */
 const toDataView = ( data: ToDataViewInput ): DataView => {
+
+	if ( typeof data === 'string' ) {
+		return toDataView( stringToBytes( data ) )
+	}
 
 	if ( Array.isArray( data ) ) {
 		return toDataView( new Uint8Array( data ).buffer )


### PR DESCRIPTION
It's now possible to get the `DataView` of a string